### PR TITLE
feat(align): adds mini.trailspace

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -22,6 +22,7 @@
   "nvim-treesitter": { "branch": "main", "commit": "ecdae44baefeffceade8b0c752d80ececad28e76" },
   "nvim-treesitter-textobjects": { "branch": "main", "commit": "a0e182ae21fda68c59d1f36c9ed45600aef50311" },
   "oil.nvim": { "branch": "master", "commit": "f55b25e493a7df76371cfadd0ded5004cb9cd48a" },
+  "mini.trailspace": { "branch": "main", "commit": "f8083ca969e1b2098480c10f3c3c4d2ce3586680" },
   "plenary.nvim": { "branch": "master", "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509" },
   "snacks.nvim": { "branch": "main", "commit": "fe7cfe9800a182274d0f868a74b7263b8c0c020b" },
   "vim-matchup": { "branch": "master", "commit": "0fb1e6b7cea34e931a2af50b8ad565c5c4fd8f4d" },

--- a/lua/peter/plugins/mini/trailspace.lua
+++ b/lua/peter/plugins/mini/trailspace.lua
@@ -1,0 +1,19 @@
+-- Highlight and remove trailspace.
+-- See https://github.com/nvim-mini/mini.trailspace'.
+
+---@type LazyPluginSpec[]
+return {
+  {
+    "echasnovski/mini.trailspace",
+    event = { "BufReadPre", "BufNewFile" },
+    opts = {},
+    init = function()
+      vim.api.nvim_create_autocmd("BufWritePre", {
+        group = require("peter.util.autocmds").augroup("TrimWhitespace"),
+        callback = function()
+          require("mini.trailspace").trim()
+        end,
+      })
+    end,
+  },
+}


### PR DESCRIPTION
This may be completely unnecessary as conform.nvim provides a whitespace-trimming formatter:
https://github.com/stevearc/conform.nvim/blob/master/lua/conform/formatters/trim_whitespace.lua